### PR TITLE
add tracking customisations for PFJet sequences

### DIFF
--- a/python/customiseTrackingForPhase2.py
+++ b/python/customiseTrackingForPhase2.py
@@ -89,7 +89,9 @@ def customiseTrackClusterRemoval(process):
     objects = ["hltIter2IterL3MuonClustersRefRemoval",    \
                "hltIter2HighPtTkMuIsoClustersRefRemoval", \
                "hltIter2HighPtTkMuClustersRefRemoval",    \
-               "hltIter1HighPtTkMuIsoClustersRefRemoval" ] 
+               "hltIter1HighPtTkMuIsoClustersRefRemoval", \
+               "hltIter1ClustersRefRemoval", \
+               "hltIter2ClustersRefRemoval" ] 
 
     for obj in objects : 
         if hasattr(process,obj) :
@@ -113,7 +115,9 @@ def customiseTrackerEventProducer(process):
     objects = [ "hltIter2IterL3MuonMaskedMeasurementTrackerEvent",    \
                 "hltIter2HighPtTkMuMaskedMeasurementTrackerEvent",    \
                 "hltIter2HighPtTkMuIsoMaskedMeasurementTrackerEvent", \
-                "hltIter1HighPtTkMuIsoMaskedMeasurementTrackerEvent" ]
+                "hltIter1HighPtTkMuIsoMaskedMeasurementTrackerEvent", \
+                "hltIter1MaskedMeasurementTrackerEvent", \
+                "hltIter2MaskedMeasurementTrackerEvent", ]
  
     for obj in objects : 
         if hasattr(process,obj) :


### PR DESCRIPTION
Hi Carlo,

I've added HLT_PFJet40 to the menu and ran on the TTBar sample. The steps I've run are: 

hltGetConfiguration --cff --offline /users/dsperka/phaseII/basic/v1.0/HLT/V8 --unprescale --l1=L1Menu_Collisions2016_v9_m2_xml > HLTrigger/Configuration/python/HLT_phaseIIbasic_cff.py

cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi --conditions auto:phase2_realistic -n 10 --era Phase2C2 --eventcontent FEVTDEBUG --relval 9000,100 -s GEN,SIM --datatier GEN-SIM --beamspot HLLHC --geometry Extended2023D4

cmsDriver.py step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:phaseIIbasic --datatier GEN-SIM-DIGI-RAW -n -1 --geometry Extended2023D4 --era Phase2C2 --eventcontent FEVTDEBUGHLT --filein=file:TTbar_13TeV_TuneCUETP8M1_cfi_GEN_SIM.root --fileout=file:step2.root --customise HLTrigger/Phase2/customiseForPhase2.customiseMuons

The menu runs and PFJet40 accepts all 10 events. The menu also includes HLT_IsoTkMu24 and HLT_M50. There is however a warning printed for every event:

%MSG-w TrackListMerger:  TrackListMerger:hltPFMuonMerging  05-May-2017 13:44:41 CEST Run: 1 Event: 1
TrackCollection InputTag:  label = hltL3TkTracksFromL2, instance =  not found
%MSG

I'll try to understand but if you have any ideas I'd be glad to hear them. 

Also if you have any suggestions on how to make some basic validation plots. The muon validation customisation looks pretty big to me...